### PR TITLE
fix: error in voice (or thread ?) text channel

### DIFF
--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -127,6 +127,7 @@ end
 
 function Interaction:_sendFollowup(payload, files)
   local data, err = self._api:createWebhookMessage(self._application_id, self._token, payload, files)
+  if not self._channel then return data, err end
   return data and self._channel._messages:_insert(data), err
 end
 

--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -127,8 +127,11 @@ end
 
 function Interaction:_sendFollowup(payload, files)
   local data, err = self._api:createWebhookMessage(self._application_id, self._token, payload, files)
-  if not self._channel then return true end
-  return data and self._channel._messages:_insert(data), err
+  if data then
+    return self._channel and self._channel._messages:_insert(data) or true
+  else
+    return false, err
+  end
 end
 
 ---Sends an interaction reply. An initial response is sent on first call of this,

--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -127,7 +127,7 @@ end
 
 function Interaction:_sendFollowup(payload, files)
   local data, err = self._api:createWebhookMessage(self._application_id, self._token, payload, files)
-  if not self._channel then return data, err end
+  if not self._channel then return true end
   return data and self._channel._messages:_insert(data), err
 end
 


### PR DESCRIPTION
Update Interaction.lua to not error when trying to save a new message in voice (and thread?) text channels because channel parent doesn't exist