### PR TITLE
made :reply() returns more consistent

### DIFF
--- a/.github/workflows/rebuild-wiki.yml
+++ b/.github/workflows/rebuild-wiki.yml
@@ -35,5 +35,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Rebuild for commit #$(git rev-parse --short --verify main)"
+          git commit -m "Rebuild for commit ${{GITHUB_SHA}}"
           git push

--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -136,7 +136,14 @@ function Interaction:_sendMessage(payload, files, deferred)
   if data then
     self._initialRes = true
     self._deferred = deferred or false
-    return true
+
+    if payload.flags and bit.band(payload.flags, messageFlag.ephemeral) ~= 0 then
+      -- message is ephemeral, therefore return true to indicate success because we can't reference the reply anyways
+      return true
+    else
+      -- message is not ephemeral, therefore return reply so it can easily be used without having to manually get the reply
+      return self:getReply() or true
+    end
   else
     return false, err
   end
@@ -155,10 +162,7 @@ end
 ---if an initial response was already sent a followup message is sent instead.
 ---If initial response was a deferred response, calling this will properly edit the deferred message.
 ---
----Returns may not be consistent because blame Discord.
----On initial response, expect this to return a boolean value representing success otherwise `false, err`.
----To get the sent reply in that case use `Interaction:getReply()`.
----On followups and edits, this will return the sent/edited message, otherwise `false, err`.
+---On both the initial response, followups and edits, this will return the sent/edited message or a boolean value representing success, otherwise `false, err`.
 ---@param content string|table
 ---@param isEphemeral? boolean
 ---@return boolean|Message

--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -142,7 +142,7 @@ function Interaction:_sendMessage(payload, files, deferred)
       return true
     else
       -- message is not ephemeral, therefore return reply so it can easily be used without having to manually get the reply
-      return self:getReply() or true
+      return self:getReply()
     end
   else
     return false, err

--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -138,7 +138,7 @@ function Interaction:_sendMessage(payload, files, deferred)
     self._deferred = deferred or false
 
     if payload.flags and bit.band(payload.flags, messageFlag.ephemeral) ~= 0 then
-      -- message is ephemeral, therefore return true to indicate success because we can't reference the reply anyways
+      -- message is ephemeral, therefore return true to indicate success because we can't modify the reply later anyways
       return true
     else
       -- message is not ephemeral, therefore return reply so it can easily be used without having to manually get the reply


### PR DESCRIPTION
Added checks to ensure a message object is returned instead of just a boolean value on the first interaction reply. Made the return more consistent to allow for better code coherence when using this library.

When I was using discordia-slash, a library depending on discordia-interactions, I was initially puzzled as to why interaction:reply() returned a boolean value initially and subsequently, message objects. It was rather an odd inconsistency.

My code used to create an initial message reply just so I could edit a message nicely later:
```lua
interaction:reply("Initial response 🗣️") -- only using this to make subsequent returns a message
-- this initial response made it so that i could assign a message to a variable later and then edit the message from the variable.
-- otherwise, i would have had to use interaction:getReply()
-- i know this is a bit lazy, but consistency in code just makes it more coherent
-- it shouldnt just seemingly arbitrarily return a boolean once and then a message for every other go
...

local message = interaction:reply("🔎 Searching for available servers...")

...

message:setContent("📥 Fetching video information...")
```

Now with the library updated, I can eliminate the initial useless reply:
```lua
...

-- makes it more obvious that :reply will always return a message
local message = interaction:reply("🔎 Searching for available servers...")

...

message:setContent("📥 Fetching video information...")
```

I'm adhering to the conventions outlined in the original comments by performing a bitwise AND operation on the message flags (if present) to check whether a message is ephemeral. if it is ephemeral, then it will return true to simply indicate success (just like it always did before, and also because we cant edit these ephemeral messages later anyways). if it is NOT ephemeral, then it will return the message object just like _sendFollowup for consistency.