### PR TITLE
Update Interaction.lua | Fix crash on message in a voice-chat chat

### DIFF
--- a/libs/containers/Interaction.lua
+++ b/libs/containers/Interaction.lua
@@ -175,7 +175,7 @@ function Interaction:_sendMessage(payload, files, deferred)
   if data then
     self._initialRes = true
     self._deferred = deferred or false
-    if self._channel then
+    if self._channel and self._channel._messages then
       return self._channel._messages:_insert(data.resource.message)
     else
       return true


### PR DESCRIPTION
probably not the best solution but it works :3

previous error: 
Uncaught Error: ...s/discordia-interactions/libs/containers/Interaction.lua:179: attempt to index field '_messages' (a nil value)